### PR TITLE
Fix gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,22 +2,7 @@
 * text=auto eol=lf
 
 # Only include the addons folder when downloading from the Asset Library.
-.gdlintrc            export-ignore
-.gitattributes       export-ignore
-.github/             export-ignore
-.gitignore           export-ignore
-.runsettings         export-ignore
-.runsettings-ci      export-ignore
-CREDITS.md           export-ignore
-LICENSE              export-ignore
-README.md            export-ignore
-icon.jpg             export-ignore
-icon.jpg.import      export-ignore
-example              export-ignore
-plugin-updater.json  export-ignore
-project.godot        export-ignore
-scripts/             export-ignore
-test/                export-ignore
-
-addons/gdUnit4        export-ignore
-addons/plugin_updater export-ignore
+/**                    export-ignore
+/addons                !export-ignore
+/addons/playlists      !export-ignore
+/addons/playlists/**   !export-ignore

--- a/addons/plugin_updater/core/plugin-updater.json
+++ b/addons/plugin_updater/core/plugin-updater.json
@@ -1,0 +1,6 @@
+{
+	"plugin_name": "plugin_updater",
+	"secs_before_check_for_update": 5,
+	"github_repo": "myyk/godot-plugin-updater",
+	"editor_plugin_meta": "PluginUpdaterEditorPlugin"
+}

--- a/addons/plugin_updater/generated/updater/plugin-updater.json
+++ b/addons/plugin_updater/generated/updater/plugin-updater.json
@@ -1,0 +1,6 @@
+{
+	"plugin_name": "plugin_updater",
+	"secs_before_check_for_update": 5,
+	"github_repo": "myyk/godot-plugin-updater",
+	"editor_plugin_meta": "PluginUpdaterEditorPlugin"
+}

--- a/addons/plugin_updater/plugin.cfg
+++ b/addons/plugin_updater/plugin.cfg
@@ -3,5 +3,5 @@
 name="plugin_updater"
 description="A plugin for plugin makers to give their plugins an easy in-editor updating."
 author="myyk"
-version="1.1.2"
+version="1.1.3"
 script="plugin_updater.gd"


### PR DESCRIPTION
The `plugin-updater.json` file was improperly being excluded from the release. I fixed the .gitattributes to use a simpler match/exclude to not have this happen again.